### PR TITLE
Add useful ruleset for protecting main branch

### DIFF
--- a/github-rulesets/Protect main.json
+++ b/github-rulesets/Protect main.json
@@ -1,0 +1,45 @@
+{
+  "id": 5607449,
+  "name": "Protect main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": true,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
Add ruleset to enforce branch protection on the main branch, including restrictions on deletions, non-fast-forward merges, and pull request requirements.